### PR TITLE
Persist database regardless of notebook or script

### DIFF
--- a/persistent-qa.ipynb
+++ b/persistent-qa.ipynb
@@ -106,8 +106,7 @@
    "metadata": {},
    "source": [
     "## Persist the Database\n",
-    "In a notebook, we should call `persist()` to ensure the embeddings are written to disk.\n",
-    "This isn't necessary in a script - the database will be automatically persisted when the client object is destroyed."
+    "We should call `persist()` to ensure the embeddings are written to disk."
    ]
   },
   {


### PR DESCRIPTION
`persist()` is required even if it's invoked in a script apart from in a notebook.

Without this, an error is thrown

```
chromadb.errors.NoIndexException: Index is not initialized
```